### PR TITLE
Implement validity checks for time points

### DIFF
--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -168,6 +168,49 @@ typedef struct rcl_time_point_s
 // } rcl_rate_t;
 // TODO(tfoote) integrate rate and timer implementations
 
+/// Check if the time point value is valid.
+/**
+ * This function returns true if the time point value is non-zero.
+ * Note that if data is uninitialized it may give a false positive.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] time_point_value the time point value which is being queried
+ * \return true if the source is believed to be valid, otherwise return false.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+bool
+rcl_time_point_value_valid(rcl_time_point_value_t time_point_value);
+
+/// Check if the time point is valid.
+/**
+ * This function returns true if the time point's value is non-zero.
+ * It will check that the type is not uninitialized.
+ * Note that if data is uninitialized it may give a false positive.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] time_point the time point which is being queried
+ * \return true if the source is believed to be valid, otherwise return false.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+bool
+rcl_time_point_valid(rcl_time_point_t * time_point);
+
 /// Check if the clock has valid values.
 /**
  * This function returns true if the time source appears to be valid.

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -73,6 +73,22 @@ rcl_get_ros_time(void * data, rcl_time_point_value_t * current_time)
 }
 
 bool
+rcl_time_point_value_valid(rcl_time_point_value_t time_point_value)
+{
+  return time_point_value > 0;
+}
+
+bool
+rcl_time_point_valid(rcl_time_point_t * time_point)
+{
+  if (time_point == NULL)
+  {
+    return false;
+  }
+  return rcl_time_point_value_valid(time_point->nanoseconds);
+}
+
+bool
 rcl_clock_valid(rcl_clock_t * clock)
 {
   if (clock == NULL ||

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -205,6 +205,29 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_ros_clock_initially_
   EXPECT_EQ(0, query_now);
 }
 
+TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), time_point_validation) {
+  ASSERT_FALSE(rcl_time_point_valid(NULL));
+
+  rcl_time_point_t uninitialized;
+  (void) uninitialized;
+  // Not reliably detectable due to random values.
+  // ASSERT_FALSE(rcl_clock_valid(&uninitialized));
+
+  rcl_time_point_t valid, invalid;
+
+  valid.nanoseconds = 1000;
+  valid.clock_type = RCL_ROS_TIME;
+
+  invalid.nanoseconds = 0;
+  invalid.clock_type = RCL_ROS_TIME;
+
+  ASSERT_TRUE(rcl_time_point_valid(&valid));
+  ASSERT_TRUE(rcl_time_point_value_valid(valid.nanoseconds));
+
+  ASSERT_FALSE(rcl_time_point_valid(&invalid));
+  ASSERT_FALSE(rcl_time_point_value_valid(invalid.nanoseconds));
+}
+
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), clock_validation) {
   ASSERT_FALSE(rcl_clock_valid(NULL));
   rcl_clock_t uninitialized;


### PR DESCRIPTION
Precursor for https://github.com/ros2/rclcpp/pull/2040

Codifies the notion of zero-time being invalid as defined in the [design docs](https://design.ros2.org/articles/clock_and_time.html), will be used in downstream rclcpp validity checks.